### PR TITLE
Alias as metric name if defined

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -112,7 +112,9 @@ function (angular, _, $, dateMath, moment) {
 
     // Convert the metadata returned from Cloudera Manager into the timeseries name for Grafana.
     this._makeTimeseriesName = function(metadata) {
-      if (metadata.metricName && metadata.entityName) {
+      if (metadata.alias) {
+        return metadata.alias;
+      } else if (metadata.metricName && metadata.entityName) {
         return metadata.metricName + ' (' + metadata.entityName  + ')';
       } else if (metadata.metricName) {
         return metadata.metricName;


### PR DESCRIPTION
Example tsquery: SELECT events_critical_rate AS "Critical Rate" WHERE category = ROLE AND roleType = NAMENODE. Metric name will be "Critical Rate".
![aliases_cm_grafana](https://cloud.githubusercontent.com/assets/3768824/12678421/a467f924-c6af-11e5-99be-6f9c0389335a.png)
